### PR TITLE
Build osrm-backend using docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
+out
 test
 build
+Dockerfile
+.github
+deploy.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,29 +1,28 @@
-name: Run tests and deploy.
+name: Build and deploy.
 
 on:
   push:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-20.04
+    env:
+      VERSION: 5.24.0
+      BUILDKIT_INLINE_CACHE: 1
+      DOCKER_BUILDKIT: 1
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install ca-certificates and https for apt
+    - name: Build osrm-backend for .deb and ECR
       run: |
-        sudo apt-get update
-        sudo apt-get install -y bash curl nodejs npm build-essential git cmake pkg-config \
-          libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev \
-          libzip-dev libboost-all-dev lua5.2 liblua5.2-dev libtbb-dev \
-          libluabind-dev libluabind0.9.1v5
+        docker build . -t osrm-backend-wgs --target builder --build-arg VERSION=$VERSION
+        docker build . -t osrm-backend-wgs --target exporter -o ./out --build-arg VERSION=$VERSION
+        docker build . -t osrm-backend-wgs --build-arg VERSION=$VERSION
 
-#    - name: Run OSRM tests
-#      run: sudo ./run_test.sh
-
-    - name: Push librairie to gemfury if branch is master
-      run: ./deploy.sh
+    - name: Push artifacts to gemfury and ECR if branch is master
+      run: ./deploy.sh 074067892588.dkr.ecr.us-east-1.amazonaws.com/woosmap/osrm-backend-wgs
       env:
-        GEMFURY_DEPLOY_TOKEN: ${{ secrets.GEMFURY_DEPLOY_TOKEN }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
         GEMFURY_USERNAME: ${{ secrets.GEMFURY_USERNAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:20.04 as builder
+
+ARG DEBIAN_FRONTEND="noninteractive"
+ENV TZ="Europe/Paris"
+
+RUN apt-get update &&  apt-get install -y curl build-essential git cmake pkg-config \
+          libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev \
+          libzip-dev libboost-all-dev lua5.2 liblua5.2-dev libtbb-dev \
+          libluabind-dev libluabind0.9.1d1
+
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+
+RUN mkdir -p build && \
+    cd build && \
+    cmake .. && \
+    make -j2 install
+
+FROM ubuntu:20.04
+
+COPY --from=builder /usr/local /usr/local
+COPY --from=builder /opt /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 as builder
 
 ARG DEBIAN_FRONTEND="noninteractive"
-ARG VERSION="test"
+ARG VERSION="0.0.0"
 ENV TZ="Europe/Paris"
 ENV PACKAGE_FILE_NAME="osrm-wgs-${VERSION}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:20.04 as builder
 
 ARG DEBIAN_FRONTEND="noninteractive"
+ARG VERSION="test"
 ENV TZ="Europe/Paris"
+ENV PACKAGE_FILE_NAME="osrm-wgs-${VERSION}"
 
 RUN apt-get update &&  apt-get install -y curl build-essential git cmake pkg-config \
           libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev \
@@ -14,7 +16,12 @@ WORKDIR /usr/src/app
 RUN mkdir -p build && \
     cd build && \
     cmake .. && \
-    make -j2 install
+    make -j2 install && \
+    cpack -G DEB -P osrmwgs -R ${VERSION} -D CPACK_PACKAGE_CONTACT=devproduit@woosmap.com -D CPACK_DEBIAN_PACKAGE_SHLIBDEPS=ON \
+    -D CPACK_PACKAGE_FILE_NAME=${PACKAGE_FILE_NAME}
+
+FROM ubuntu:20.04 as exporter
+COPY --from=builder /usr/src/app/build /build
 
 FROM ubuntu:20.04
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
-## Open Source Routing Machine
+## Open Source Routing Machine With Woosmap changes...
+
+# WGS
+To build this repo locally use the Dockerfile in the root of the directory.
+```bash
+docker build . -t osrm-backend-wgs
+```
+You may need to modify your Docker Desktop settings to succeed. I found 6 CPUs and 10 GB of memory did the trick.
+
+
+In order to build this repo to get a .deb file build it slightly differently:
+```bash
+DOCKER_BUILDKIT=1 docker build . -t osrm-backend-wgs --target exporter -o ./out
+```
+Once that build has finished the osrm-wgs-0.0.0.deb will be availble in the `./out/build` folder.
+
+
+To test any changes you will need to pair this repo with [pylibosrm](https://github.com/WebGeoServices/pylibosrm) and 
+build the Dockerfile located there with the FROM part at the top pointing to your latest docker image locally.
+Or install the .deb pacakege on appropriate EC2 server in AWS.
+
 
 | Linux / macOS | Windows | Code Coverage |
 | ------------- | ------- | ------------- |


### PR DESCRIPTION
I will link other related PRs below:
- https://github.com/WebGeoServices/pylibosrm/pull/9
- https://github.com/WebGeoServices/distance/pull/79

But these PRs all relate on how to docker containers instead of gemfury and .deb files to pass around osrm-backend and pylibosrm to the places that they are needed mostly being distance.
The tests that run with pylibosrm and distance are both passing this way.

Simply put these 3 PRs work together in that when we build osrm-backed we would push the container to ECR.
This container would then be the base image used by pylibosrm's container build which, when it is built would be pushed to ECR.
And then this image would become the base image for the distance image.
Development locally would skip the ECR part and rely on local images.

`osrm-backend-wgs        latest    da9b551cf747   2 hours ago         126MB`
`pylibosrmwgs            latest    0a7a36b93105   22 minutes ago      278MB`
`distance                latest    9fedb98208b7   10 minutes ago      782MB` I think something funny in my local is making this bigger than it should be 

